### PR TITLE
Revert "Implemented #, g*, g#, and other changes."

### DIFF
--- a/doc/stim.txt
+++ b/doc/stim.txt
@@ -50,20 +50,12 @@ was an itch that this plugin aims to scratch.
 ====================================================================
 Section 3: Mappings                                    *StImMappings*
 
-The StIm plugin remaps *, #, g*, and g# to do the following, in order:
-
-    1. Call the script's updateState command,
-
-    2. Perform the appropriate jump (or not, depending on the state),
-
-    3. Set |hlsearch|,
-
-    4. And set |v:searchforward| appropriately.
+The StIm plugin will remap * to activate the StIm command and then |hlsearch|.
 
 The user is advised to have mapping to toggle or deactivate |hlsearch|.
 Example:
 
-nnoremap <silent> <leader><space> :set hlsearch! hlsearch?<CR>
+nnoremap <silent> <leader><space> :set hlsearch! hlsearch?<CR>:call clearmatches()<CR>
 
 ====================================================================
 Section 4: License                                     *StImLicense*
@@ -94,6 +86,9 @@ SOFTWARE.
 Section 5: Bugs                                        *StImBugs*
 
 Currently, the StIm plugin does not take a [count].
+
+The *#* command is not implemented and will not be done, unless
+somebody issues a pull request.
 
 Please submit bugs to:
 https://github.com/ironhouzi/vim-stim/issues

--- a/plugin/stim.vim
+++ b/plugin/stim.vim
@@ -7,7 +7,7 @@ if exists('g:loaded_stim_plugin')
 endif
 let g:loaded_stim_plugin = 1
 
-function s:updateState()
+function! StIm()
     let s:searchword = expand("<cword>")
 
     if !exists('b:virginstar')
@@ -26,67 +26,16 @@ function s:updateState()
         let b:virginstar = 1
         let b:lastterm = s:searchword
     endif
-endfunction
 
-function s:frwdWord()
     let @/ = "\\<". b:lastterm ."\\>"
 
     if b:virginstar
-        " Set the previous context mark on the word searched from.
-        call setpos("''", getcurpos())
+        execute "normal! /\\<". b:lastterm ."\\>"
     else
-        call search("\\<". b:lastterm ."\\>")
+        execute "normal! n"
     endif
 
     let b:virginstar = 0
 endfunction
 
-function s:bkwdWord()
-    let @/ = "\\<". b:lastterm ."\\>"
-
-    if b:virginstar
-        call setpos("''", getcurpos())
-    else
-        call search("\\<". b:lastterm ."\\>", "b")
-    endif
-
-    let b:virginstar = 0
-endfunction
-
-function s:frwdPrtl()
-    let @/ = b:lastterm
-
-    if b:virginstar
-        call setpos("''", getcurpos())
-    else
-        call search(b:lastterm)
-    endif
-
-    let b:virginstar = 0
-endfunction
-
-function s:bkwdPrtl()
-    let @/ = b:lastterm
-
-    if b:virginstar
-        call setpos("''", getcurpos())
-    else
-        call search(b:lastterm, "b")
-    endif
-
-    let b:virginstar = 0
-endfunction
-
-nnoremap <silent> <Plug>StImFrwdWord :call <SID>updateState()<CR>:call <SID>frwdWord()<CR>:set hlsearch<CR>:let v:searchforward=1<CR>
-nnoremap <silent> <Plug>StImBkwdWord :call <SID>updateState()<CR>:call <SID>bkwdWord()<CR>:set hlsearch<CR>:let v:searchforward=0<CR>
-nnoremap <silent> <Plug>StImFrwdPrtl :call <SID>updateState()<CR>:call <SID>frwdPrtl()<CR>:set hlsearch<CR>:let v:searchforward=1<CR>
-nnoremap <silent> <Plug>StImBkwdPrtl :call <SID>updateState()<CR>:call <SID>bkwdPrtl()<CR>:set hlsearch<CR>:let v:searchforward=0<CR>
-
-if !exists("g:stim_no_mappings") || ! g:stim_no_mappings
-    nmap * <Plug>StImFrwdWord
-    nmap # <Plug>StImBkwdWord
-    nmap g* <Plug>StImFrwdPrtl
-    nmap g# <Plug>StImBkwdPrtl
-endif
-
-" vim:set ft=vim sw=4 sts=4 et:
+execute "nnoremap <silent> * :call StIm()<CR>:set hlsearch<CR>"


### PR DESCRIPTION
Reverts ironhouzi/vim-stim#1

My version of Vim (7.4) doesn't have any function called getcurpos()
